### PR TITLE
Add --remove option to oci-ctl load

### DIFF
--- a/doc/oci-ctl-load.rst
+++ b/doc/oci-ctl-load.rst
@@ -17,6 +17,7 @@ SYNOPSIS
    OPTIONS:
        -h, --help         Print help information
            --oci <OCI>    OCI image to load into local podman registry
+           --remove       Remove given OCI image after loading to local registry
        -V, --version      Print version information
 
 
@@ -40,12 +41,17 @@ OPTIONS
   container must be in the OCI tar format like it is produced
   when exporting containers from registries via **podman export**
 
+--remove
+
+  Remove given OCI image file, after successful loading into the
+  local registry.
+
 EXAMPLE
 -------
 
 .. code:: bash
 
-   $ oci-ctl load --oci SOME.docker.tar
+   $ oci-ctl load --oci SOME.docker.tar --remove
 
 AUTHOR
 ------

--- a/oci-ctl/src/cli.rs
+++ b/oci-ctl/src/cli.rs
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-use clap::{AppSettings, Parser, Subcommand, ArgGroup};
+use clap::{AppSettings, Parser, Subcommand, ArgGroup, ArgAction};
 
 /// oci-ctl - Load and Register OCI applications
 #[derive(Parser)]
@@ -40,6 +40,10 @@ pub enum Commands {
         /// OCI image to load into local podman registry
         #[clap(long)]
         oci: String,
+
+        /// Remove given OCI image after loading to local registry
+        #[clap(long, action=ArgAction::SetFalse)]
+        remove: bool,
     },
     /// Remove application registration or entire container
     #[clap(group(

--- a/oci-ctl/src/main.rs
+++ b/oci-ctl/src/main.rs
@@ -41,8 +41,8 @@ fn main() {
 
     match &args.command {
         // load
-        cli::Commands::Load { oci } => {
-            exit(podman::load(oci));
+        cli::Commands::Load { oci, remove } => {
+            exit(podman::load(oci, *remove));
         },
         // list
         cli::Commands::List { } => {

--- a/oci-ctl/src/podman.rs
+++ b/oci-ctl/src/podman.rs
@@ -23,8 +23,9 @@
 //
 use std::process::Command;
 use crate::defaults;
+use std::fs;
 
-pub fn load(oci: &String) -> i32 {
+pub fn load(oci: &String, remove: bool) -> i32 {
     /*!
     Call podman load with the provided oci tar file
     !*/
@@ -43,6 +44,15 @@ pub fn load(oci: &String) -> i32 {
             status_code = status.code().unwrap();
             if ! status.success() {
                 error!("Failed, error message(s) reported");
+            } else if remove {
+                info!("Removing OCI image {}", oci);
+                match fs::remove_file(oci) {
+                    Ok(_) => {},
+                    Err(error) => {
+                        error!("Removing {} failed with: {:?}", oci, error);
+                        status_code = 1;
+                    }
+                }
             }
         }
         Err(status) => { error!("Process terminated by signal: {}", status) }


### PR DESCRIPTION
Allow to remove the given OCI image file after it has been loaded into the local registry