### PR TITLE
Added support for resume/respawn

### DIFF
--- a/doc/oci-pilot.rst
+++ b/doc/oci-pilot.rst
@@ -62,6 +62,25 @@ can be set:
    # Optional registration setup
    # Container runtime parameters
    runtime:
+     # Try to resume container from previous execution.
+     # If the container is still running, the call will attach to it
+     # If the container is not running, the call will restart the
+     # container and attach to it.
+     #
+     # NOTE: If processing the call inside of the container finishes
+     # faster than attaching to it, the call will run a new container
+     # which is attached immediately. If this is unwanted set:
+     # respawn: false
+     #
+     # Default: false
+     resume: true|false
+
+     # Run a new container if attaching to resumed container failed
+     # This setting is only effective if 'resume: true' is set
+     #
+     # Default: true
+     respawn: true|false
+
      # Caller arguments for the podman engine in the format:
      # - PODMAN_OPTION_NAME_AND_OPTIONAL_VALUE
      # For details on podman options please consult the
@@ -79,6 +98,14 @@ defaults will apply:
 
 - The container will be removed after the call
 - The container allows for interactive shell sessions
+
+All caller arguments will be passed to the program call inside
+of the container except for arguments that starts with the '@'
+sign. Caller arguments of this type are only used in the container
+ID file name but will not be passed to the program call inside of
+the container. This allows users to differentiate the same
+program call between different container instances when using
+a resume based flake setup.
 
 FILES
 -----

--- a/oci-pilot/src/defaults.rs
+++ b/oci-pilot/src/defaults.rs
@@ -22,3 +22,5 @@
 // SOFTWARE.
 //
 pub const CONTAINER_FLAKE_DIR: &str = "/usr/share/flakes";
+pub const CONTAINER_CID_DIR: &str = "/tmp/flakes";
+pub const GC_THRESHOLD: i32 = 20;

--- a/oci-pilot/src/podman.rs
+++ b/oci-pilot/src/podman.rs
@@ -21,11 +21,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-use std::process::Command;
+use std::path::Path;
+use std::process::{Command, Stdio};
 use std::process::exit;
 use std::env;
+use std::fs;
 use crate::app_path::program_config;
 use crate::app_path::program_config_file;
+
+use crate::defaults;
 
 pub fn run(program_name: &String) {
     /*!
@@ -47,6 +51,25 @@ pub fn run(program_name: &String) {
     host_app_path: path/to/program/on/host
 
     runtime:
+      # Try to resume container from previous execution.
+      # If the container is still running, the call will attach to it
+      # If the container is not running, the call will restart the
+      # container and attach to it.
+      #
+      # NOTE: If processing the call inside of the container finishes
+      # faster than attaching to it, the call will run a new container
+      # which is attached immediately. If this is unwanted set:
+      # respawn: false
+      #
+      # Default: false
+      resume: true|false
+
+      # Run a new container if attaching to resumed container failed
+      # This setting is only effective if 'resume: true' is set
+      #
+      # Default: true
+      respawn: true|false
+
       podman:
         - --storage-opt size=10G
         - --rm:
@@ -59,6 +82,14 @@ pub fn run(program_name: &String) {
     let args: Vec<String> = env::args().collect();
 
     let runtime_config = program_config(&program_name);
+    let mut container_cid_file = format!(
+        "{}/{}", defaults::CONTAINER_CID_DIR, program_name
+    );
+    for arg in &args[1..] {
+        // build container ID file specific to the caller arguments
+        container_cid_file = format!("{}{}", container_cid_file, arg);
+    }
+    container_cid_file = format!("{}.cid", container_cid_file);
 
     let mut app = Command::new("podman");
 
@@ -78,10 +109,88 @@ pub fn run(program_name: &String) {
         target_app_path = runtime_config[0]["target_app_path"].as_str().unwrap();
     }
 
-    // setup podman runtime arguments
-    app.arg("run");
-    let mut has_runtime_arguments: bool = false;
+    // get runtime section
     let runtime_section = &runtime_config[0]["runtime"];
+
+    // setup container operation mode
+    let mut resume: bool = false;
+    let mut respawn: bool = true;
+
+    if ! runtime_section.as_hash().is_none() {
+        if ! &runtime_section["resume"].as_bool().is_none() {
+            resume = runtime_section["resume"].as_bool().unwrap();
+        }
+        if ! &runtime_section["respawn"].as_bool().is_none() {
+            respawn = runtime_section["respawn"].as_bool().unwrap();
+        }
+    }
+
+    if resume {
+        // Make sure CID dir exists
+        if ! Path::new(defaults::CONTAINER_CID_DIR).is_dir() {
+            fs::create_dir(defaults::CONTAINER_CID_DIR).unwrap_or_else(|why| {
+                panic!("Failed to create CID dir: {:?}", why.kind());
+            });
+        }
+
+        // Garbage collect occasionally
+        gc();
+
+        if ! Path::new(&container_cid_file).exists() {
+            // resume mode is active and container doesn't exist
+            // run the container and init a new ID file
+            app.arg("run");
+            app.arg("--cidfile");
+            app.arg(container_cid_file);
+        } else {
+            // resume mode is active and container exists
+            // either attach or restart to it
+            match fs::read_to_string(&container_cid_file) {
+                Ok(cid) => {
+                    // debug!("{:?}", cid);
+                    // 1. try to attach to the container
+                    if resume_instance("attach", &cid) == 0 {
+                        exit(0)
+                    }
+                    // 2. try to restart/attach to the container
+                    if resume_instance("restart", &cid) == 0 {
+                        if resume_instance("attach", &cid) == 0 {
+                            exit(0)
+                        } else if ! respawn {
+                            // attach failed, mostly because the process
+                            // started already finished. By default we
+                            // run a new container that is attached immediately
+                            // but no respawn indicates this is unwanted.
+                            // So we are leaving...
+                            exit(0)
+                        }
+                    }
+                    // 3. resume failed, delete instance and CID and re-init
+                    resume_instance("rm", &cid);
+                    match fs::remove_file(&container_cid_file) {
+                        Ok(_) => { },
+                        Err(error) => {
+                            error!("Failed to remove CID: {:?}", error)
+                        }
+                    }
+                    app.arg("run");
+                    app.arg("--cidfile");
+                    app.arg(container_cid_file);
+                },
+                Err(error) => {
+                    // cid file exists but could not be read
+                    // fallback to start a new container without CID
+                    error!("Error reading CID: {:?}", error);
+                    app.arg("run");
+                }
+            }
+        }
+    } else {
+        app.arg("run");
+    }
+
+    // run the container and application
+    let mut has_runtime_arguments: bool = false;
     if ! runtime_section.as_hash().is_none() {
         let podman_section = &runtime_section["podman"];
         if ! podman_section.as_vec().is_none() {
@@ -109,19 +218,87 @@ pub fn run(program_name: &String) {
 
     // setup program arguments
     for arg in &args[1..] {
-        app.arg(arg);
+        if ! arg.starts_with("@") {
+            app.arg(arg);
+        }
     }
 
     // debug!("{:?}", app.get_args());
-
     match app.status() {
         Ok(status) => {
             match status.code() {
                 Some(code) => exit(code),
-                None => error!("Process terminated by signal")
+                None => panic!("Process terminated by signal")
             }
         },
         Err(error) => error!("Failed to execute podman: {:?}", error)
-    };
-    exit(255);
+    }
+    exit(255)
+}
+
+pub fn resume_instance(action: &str, cid: &String) -> i32 {
+    /*!
+    Call container ID based podman commands
+    !*/
+    let mut resume = Command::new("podman");
+    resume.stderr(Stdio::null());
+    if action == "restart" || action == "rm" {
+        resume.stdout(Stdio::null());
+    }
+    resume.arg(action).arg(&cid);
+    let mut status_code = 255;
+    match resume.status() {
+        Ok(status) => {
+            status_code = status.code().unwrap();
+        },
+        Err(error) => {
+            error!("Failed to execute podman {}: {:?}", action, error)
+        }
+    }
+    status_code
+}
+
+pub fn gc() {
+    /*!
+    Garbage collect CID files for which no container exists anymore
+    !*/
+    let mut cid_file_names: Vec<String> = Vec::new();
+    let mut cid_file_count: i32 = 0;
+    let paths = fs::read_dir(defaults::CONTAINER_CID_DIR).unwrap();
+    for path in paths {
+        cid_file_names.push(format!("{}", path.unwrap().path().display()));
+        cid_file_count = cid_file_count + 1;
+    }
+    if cid_file_count <= defaults::GC_THRESHOLD {
+        return
+    }
+    for container_cid_file in cid_file_names {
+        match fs::read_to_string(&container_cid_file) {
+            Ok(cid) => {
+                let mut exists = Command::new("podman");
+                exists.arg("container").arg("exists").arg(&cid);
+                match exists.status() {
+                    Ok(status) => {
+                        if status.code().unwrap() != 0 {
+                            match fs::remove_file(&container_cid_file) {
+                                Ok(_) => { },
+                                Err(error) => {
+                                    error!("Failed to remove CID: {:?}", error)
+                                }
+                            }
+                        }
+                    },
+                    Err(error) => {
+                        error!(
+                            "Failed to execute podman container exists: {:?}",
+                            error
+                        )
+                    }
+                }
+            },
+            Err(error) => {
+                error!("Error reading CID: {:?}", error);
+            }
+        }
+    }
 }

--- a/package/debbuild/oci-pilot.spec
+++ b/package/debbuild/oci-pilot.spec
@@ -78,9 +78,12 @@ make build
 
 %install
 make DESTDIR=%{buildroot}/ install
+mkdir -p -m 777 %{buildroot}/usr/share/flakes
+
 
 %files
 %defattr(-,root,root)
+%dir /usr/share/flakes
 /usr/bin/oci-pilot
 /usr/bin/oci-ctl
 %doc /usr/share/man/man8/*


### PR DESCRIPTION
Using resume in the flake setup will re-attach to the running container instead of starting a new one. This setting is useful for interactive container sessions as well as for long running processes, e.g services. This Fixes #32