### PR TITLE
Add commandline switches for attach/resume setting

### DIFF
--- a/doc/oci-ctl-register.rst
+++ b/doc/oci-ctl-register.rst
@@ -18,6 +18,9 @@ SYNOPSIS
        --app <APP>                An absolute path to the application on the host. If not
                                   specified via the target option, the application will be
                                   called with that path inside of the container
+       --attach <ATTACH>          Attach to the container if still running, rather than executing
+                                  the app again. Only makes sense for interactive sessions like a
+                                  shell application
        --base <BASE>              Name of the base container. The name must match with a name in
                                   the local podman registry
        --container <CONTAINER>    A container name. The name must match with a name in the local
@@ -27,6 +30,9 @@ SYNOPSIS
                                   base container. This option can be specified multiple times. The
                                   resulting layer list is evaluated in the order of the arguments
                                   as they were provided on the command line
+       --resume <RESUME>          Resume the container from previous execution. If the container is
+                                  still running, the app will be executed inside of this container
+                                  instance
        --target <TARGET>          An absolute path to the application in the container. Use this option
                                   if the application path on the host should be different to the
                                   application path inside of the container. Set this option to an empty string

--- a/oci-ctl/src/app.rs
+++ b/oci-ctl/src/app.rs
@@ -30,7 +30,8 @@ use glob::glob;
 pub fn register(
     container: &String, app: &String,
     target: Option<&String>, base: Option<&String>,
-    layers: Option<Vec<String>>
+    layers: Option<Vec<String>>, resume: Option<&bool>,
+    attach: Option<&bool>
 ) {
     /*!
     Register container application.
@@ -39,20 +40,7 @@ pub fn register(
     pointing to the oci-pilot launcher. Second it will create an
     app configuration file as CONTAINER_FLAKE_DIR/app.yaml containing
     the required information to launch the application inside of
-    the container as follows:
-
-    container: container
-    target_app_path: path/to/program/in/container
-    host_app_path: path/to/program/on/host
-    base_container: base_container_name
-
-    layer:
-      - name_A
-      - name_B
-
-    runtime:
-      podman:
-        - option: [value]
+    the container.
     !*/
     let host_app_path = app;
     let mut target_app_path = host_app_path;
@@ -101,7 +89,8 @@ pub fn register(
     };
     match app_config::AppConfig::save(
         Path::new(&app_config_file),
-        &container, &target_app_path, &host_app_path, base, layers
+        &container, &target_app_path, &host_app_path,
+        base, layers, resume, attach
     ) {
         Ok(_) => { },
         Err(error) => {

--- a/oci-ctl/src/app_config.rs
+++ b/oci-ctl/src/app_config.rs
@@ -50,7 +50,8 @@ impl AppConfig {
     pub fn save(
         config_file: &Path, container: &String, target_app_path: &String,
         host_app_path: &String, base: Option<&String>,
-        layers: Option<Vec<String>>
+        layers: Option<Vec<String>>, resume: Option<&bool>,
+        attach: Option<&bool>
     ) -> Result<(), GenericError> {
         /*!
         save stores an AppConfig to the given file
@@ -68,6 +69,18 @@ impl AppConfig {
         if ! layers.is_none() {
             yaml_config.layers = Some(layers.as_ref().unwrap().to_vec());
         }
+        if ! resume.is_none() && *resume.unwrap() == true {
+            yaml_config.runtime.as_mut().unwrap()
+                .resume = Some(*resume.unwrap());
+        } else if ! attach.is_none() && *attach.unwrap() == true {
+            yaml_config.runtime.as_mut().unwrap()
+                .attach = Some(*attach.unwrap());
+        } else {
+            // default: remove the container if no resume/attach is set
+            yaml_config.runtime.as_mut().unwrap()
+                .podman.as_mut().unwrap().push(format!("--rm"));
+        }
+
         let config = std::fs::OpenOptions::new()
             .write(true)
             .create(true)

--- a/oci-ctl/src/cli.rs
+++ b/oci-ctl/src/cli.rs
@@ -63,6 +63,9 @@ pub enum Commands {
         app: Option<String>,
     },
     /// Register container application
+    #[clap(group(
+        ArgGroup::new("register").required(false).args(&["resume", "attach"]),
+    ))]
     Register {
         /// A container name. The name must match with a
         /// name in the local podman registry
@@ -97,6 +100,18 @@ pub enum Commands {
         /// were provided on the command line.
         #[clap(long, multiple = true)]
         layer: Option<Vec<String>>,
+
+        /// Resume the container from previous execution.
+        /// If the container is still running, the app will be
+        /// executed inside of this container instance.
+        #[clap(long)]
+        resume: Option<bool>,
+
+        /// Attach to the container if still running, rather than
+        /// executing the app again. Only makes sense for interactive
+        /// sessions like a shell application.
+        #[clap(long)]
+        attach: Option<bool>,
     },
     /// List registered container applications
     List {

--- a/oci-ctl/src/main.rs
+++ b/oci-ctl/src/main.rs
@@ -61,11 +61,13 @@ fn main() {
             }
         },
         // register
-        cli::Commands::Register { container, app, target, base, layer } => {
+        cli::Commands::Register {
+            container, app, target, base, layer, resume, attach
+        } => {
             if app::init() {
                 app::register(
                     container, app, target.as_ref(), base.as_ref(),
-                    layer.as_ref().cloned()
+                    layer.as_ref().cloned(), resume.as_ref(), attach.as_ref()
                 );
             }
         },

--- a/oci-ctl/template/flake.yaml
+++ b/oci-ctl/template/flake.yaml
@@ -1,3 +1,11 @@
 container: name
 target_app_path: path/to/program/in/container
 host_app_path: path/to/program/on/host
+base_container: ~
+layers: ~
+runtime:
+  runas: root
+  resume: false
+  attach: false
+  podman:
+    - "-ti"


### PR DESCRIPTION
Allow to specify --attach or --resume setting at app registration.

This Fixes #48 and Fixes #39