### PR TITLE
Add support for podman settings on the commandline

### DIFF
--- a/doc/oci-ctl-podman-register.rst
+++ b/doc/oci-ctl-podman-register.rst
@@ -21,6 +21,7 @@ SYNOPSIS
        --container <CONTAINER>
        --include-tar <INCLUDE_TAR>...
        --layer <LAYER>...
+       --opt <OPT>...
        --resume <true|false>
        --run-as <RUN_AS>
        --target <TARGET>
@@ -78,6 +79,17 @@ OPTIONS
   resulting layer list is evaluated in the order of the arguments
   as they were provided on the command line
 
+--opt <OPT>...
+
+  Container runtime option, and optional value, used to create the
+  container. This option can be specified multiple times.
+  If no options are specified the container always starts with
+  terminal emulation activated "-ti". In addition if none of
+  --resume or --attach is set, the container will be deleted by
+  default "--rm". If runtime option(s) are specified none of the
+  default settings will apply. See the example section for further
+  details.
+
 --resume <RESUME>
 
   Resume the container from previous execution. If the container is
@@ -119,6 +131,12 @@ EXAMPLE
 
    $ oci-ctl podman register --container SOME_APT_CONTAINER \
        --app /usr/bin/apt-get
+
+   $ oci-ctl podman register --container SOME_APT_CONTAINER \
+       --app /usr/bin/apt-get \
+       --opt '\-ti' \
+       --opt '\--rm' \
+       --opt '\--storage-opt size=10G'
 
 AUTHOR
 ------

--- a/oci-ctl/src/app.rs
+++ b/oci-ctl/src/app.rs
@@ -36,7 +36,8 @@ pub fn register(
     includes_tar: Option<Vec<String>>,
     resume: Option<&bool>,
     attach: Option<&bool>,
-    run_as: Option<&String>
+    run_as: Option<&String>,
+    opts: Option<Vec<String>>
 ) {
     /*!
     Register container application.
@@ -104,7 +105,7 @@ pub fn register(
     match app_config::AppConfig::save(
         Path::new(&app_config_file),
         &container, &target_app_path, &host_app_path,
-        base, layers, includes_tar, resume, attach, run_as
+        base, layers, includes_tar, resume, attach, run_as, opts
     ) {
         Ok(_) => { },
         Err(error) => {

--- a/oci-ctl/src/app_config.rs
+++ b/oci-ctl/src/app_config.rs
@@ -67,7 +67,8 @@ impl AppConfig {
         includes_tar: Option<Vec<String>>,
         resume: Option<&bool>,
         attach: Option<&bool>,
-        run_as: Option<&String>
+        run_as: Option<&String>,
+        opts: Option<Vec<String>>
     ) -> Result<(), GenericError> {
         /*!
         save stores an AppConfig to the given file
@@ -109,6 +110,19 @@ impl AppConfig {
         if ! includes_tar.is_none() {
             yaml_config.include.tar = Some(
                 includes_tar.as_ref().unwrap().to_vec()
+            );
+        }
+        if ! opts.is_none() {
+            let mut final_opts: Vec<String> = Vec::new();
+            for opt in opts.as_ref().unwrap() {
+                if opt.chars().next().unwrap() == '\\' {
+                    final_opts.push(opt[1..].to_string())
+                } else {
+                    final_opts.push(opt.to_string())
+                }
+            }
+            yaml_config.container.runtime.as_mut().unwrap().podman = Some(
+                final_opts
             );
         }
 

--- a/oci-ctl/src/cli.rs
+++ b/oci-ctl/src/cli.rs
@@ -139,6 +139,12 @@ pub enum Podman {
         /// container registries.
         #[clap(long)]
         run_as: Option<String>,
+
+        /// Container runtime option, and optional value, used to
+        /// create the container. This option can be
+        /// specified multiple times.
+        #[clap(long, multiple = true)]
+        opt: Option<Vec<String>>,
     },
     /// Build container package
     BuildDeb {

--- a/oci-ctl/src/main.rs
+++ b/oci-ctl/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
                 // register
                 cli::Podman::Register {
                     container, app, target, base,
-                    layer, include_tar, resume, attach, run_as
+                    layer, include_tar, resume, attach, run_as, opt
                 } => {
                     if app::init() {
                         app::register(
@@ -78,7 +78,8 @@ fn main() {
                             include_tar.as_ref().cloned(),
                             resume.as_ref(),
                             attach.as_ref(),
-                            run_as.as_ref()
+                            run_as.as_ref(),
+                            opt.as_ref().cloned()
                         );
                     }
                 },


### PR DESCRIPTION
Allow to specify podman runtime options as part of the flake registration. This Fixes #41